### PR TITLE
Update code-submitter to use file backend

### DIFF
--- a/modules/www/manifests/code_submitter.pp
+++ b/modules/www/manifests/code_submitter.pp
@@ -12,7 +12,6 @@ class www::code_submitter  (
     group     => 'apache',
   }
 
-  $verify_tls = !$devmode
   $env_file = "${root_dir}/.env"
   file { $env_file:
     ensure  => present,

--- a/modules/www/manifests/code_submitter.pp
+++ b/modules/www/manifests/code_submitter.pp
@@ -22,6 +22,14 @@ class www::code_submitter  (
     require => Vcsrepo[$root_dir],
   }
 
+  file { '/etc/sr/code-submitter-credentials.yaml':
+    ensure => present,
+    owner => 'wwwcontent',
+    group => 'apache',
+    mode => '440',
+    source => "/srv/secrets/code-submitter-credentials.yaml",
+  }
+
   package { 'make':
     ensure  => present,
   }

--- a/modules/www/manifests/code_submitter.pp
+++ b/modules/www/manifests/code_submitter.pp
@@ -27,7 +27,7 @@ class www::code_submitter  (
     owner => 'wwwcontent',
     group => 'apache',
     mode => '440',
-    source => "/srv/secrets/code-submitter-credentials.yaml",
+    source => '/srv/secrets/code-submitter-credentials.yaml',
     require => File['/etc/sr'],
   }
 

--- a/modules/www/manifests/code_submitter.pp
+++ b/modules/www/manifests/code_submitter.pp
@@ -28,7 +28,7 @@ class www::code_submitter  (
     group => 'apache',
     mode => '440',
     source => "/srv/secrets/code-submitter-credentials.yaml",
-    require => File['/etc/sr']
+    require => File['/etc/sr'],
   }
 
   package { 'make':

--- a/modules/www/manifests/code_submitter.pp
+++ b/modules/www/manifests/code_submitter.pp
@@ -28,7 +28,7 @@ class www::code_submitter  (
     group => 'apache',
     mode => '440',
     source => "/srv/secrets/code-submitter-credentials.yaml",
-    require => File["/etc/sr"]
+    require => File['/etc/sr']
   }
 
   package { 'make':

--- a/modules/www/manifests/code_submitter.pp
+++ b/modules/www/manifests/code_submitter.pp
@@ -28,6 +28,7 @@ class www::code_submitter  (
     group => 'apache',
     mode => '440',
     source => "/srv/secrets/code-submitter-credentials.yaml",
+    require => File["/etc/sr"]
   }
 
   package { 'make':

--- a/modules/www/manifests/ide.pp
+++ b/modules/www/manifests/ide.pp
@@ -298,6 +298,6 @@ class www::ide (
     group => 'apache',
     mode => '440',
     source => "/srv/secrets/wifi-keys.yaml",
-    require => File["/etc/sr"]
+    require => File['/etc/sr']
   }
 }

--- a/modules/www/manifests/ide.pp
+++ b/modules/www/manifests/ide.pp
@@ -292,20 +292,12 @@ class www::ide (
 
   # Install the wifi keys that get exported in robot.zip into /etc, for reading
   # by the IDE.
-  # The creation of the /etc/sr directory could be somewhere better; that can
-  # be improved at a later date.
-  file { '/etc/sr':
-    ensure => directory,
-    owner => 'root',
-    group => 'root',
-    mode => '755',
-  }
-
   file { '/etc/sr/wifi-keys.yaml':
     ensure => present,
     owner => 'wwwcontent',
     group => 'apache',
     mode => '440',
     source => "/srv/secrets/wifi-keys.yaml",
+    require => File["/etc/sr"]
   }
 }

--- a/modules/www/manifests/init.pp
+++ b/modules/www/manifests/init.pp
@@ -31,6 +31,13 @@ class www( $git_root ) {
     require => Package['httpd'],
   }
 
+  file { '/etc/sr':
+    ensure => directory,
+    owner => 'root',
+    group => 'root',
+    mode => '755',
+  }
+
   # Home dir needed so it can run cron jobs.
   file { '/home/wwwcontent':
     ensure  => directory,

--- a/modules/www/manifests/init.pp
+++ b/modules/www/manifests/init.pp
@@ -31,13 +31,6 @@ class www( $git_root ) {
     require => Package['httpd'],
   }
 
-  file { '/etc/sr':
-    ensure => directory,
-    owner => 'root',
-    group => 'root',
-    mode => '755',
-  }
-
   # Home dir needed so it can run cron jobs.
   file { '/home/wwwcontent':
     ensure  => directory,
@@ -64,6 +57,13 @@ class www( $git_root ) {
   }
 
   if $competitor_services {
+    file { '/etc/sr':
+      ensure => directory,
+      owner => 'root',
+      group => 'root',
+      mode => '755',
+    }
+
     # Python 2.7.5 docs -- version match the python on the BBs
     class { 'www::python_docs':
       web_root_dir => $web_root_dir,

--- a/modules/www/manifests/init.pp
+++ b/modules/www/manifests/init.pp
@@ -56,14 +56,14 @@ class www( $git_root ) {
     content => "<h2>${::hostname}</h2>",
   }
 
-  if $competitor_services {
-    file { '/etc/sr':
-      ensure => directory,
-      owner => 'root',
-      group => 'root',
-      mode => '755',
-    }
+  file { '/etc/sr':
+    ensure => directory,
+    owner => 'root',
+    group => 'root',
+    mode => '755',
+  }
 
+  if $competitor_services {
     # Python 2.7.5 docs -- version match the python on the BBs
     class { 'www::python_docs':
       web_root_dir => $web_root_dir,

--- a/modules/www/templates/code-submitter.env.erb
+++ b/modules/www/templates/code-submitter.env.erb
@@ -1,1 +1,1 @@
-AUTH_BACKEND={"backend":"code_submitter.auth.NemesisBackend","kwargs":{"url":"https://<%= @fqdn %>/userman/","verify":<%= @verify_tls %>}}
+AUTH_BACKEND={"backend":"code_submitter.auth.FileBackend","kwargs":{"path":"/srv/secrets/code-submitter-credentials.yaml"}}

--- a/modules/www/templates/code-submitter.env.erb
+++ b/modules/www/templates/code-submitter.env.erb
@@ -1,1 +1,1 @@
-AUTH_BACKEND={"backend":"code_submitter.auth.FileBackend","kwargs":{"path":"/srv/secrets/code-submitter-credentials.yaml"}}
+AUTH_BACKEND={"backend":"code_submitter.auth.FileBackend","kwargs":{"path":"/etc/sr/code-submitter-credentials.yaml"}}

--- a/new-machine.md
+++ b/new-machine.md
@@ -62,6 +62,9 @@
        ```bash
        /etc/puppet/scripts/generate-wifi-keys.py > /srv/secrets/wifi-keys.yaml
        ```
+     - `code-submitter-credentials.yaml`; this should be a YAML file in the same format
+       as `wifi-keys.yaml` (and thus generated using the same script). In addition to
+       competing teams, the TLA "SRX" should be provided for volunteer login.
 
      - `ide/notifications`, `ide/repos` and `ide/settings`; these should be
        non-empty directories:
@@ -136,5 +139,5 @@
     4. Create an app to use (or click through to an existing one) and then to
        "Add features and functionality" and then "Incoming Webhooks".
     5. Copy the Webhook URL for the app.
-    7. Go to the Extension page in the Admin Control Panel of the forums
-    6. Paste the Webhook URL into the "Incoming webhook url" field & Submit
+    6. Go to the Extension page in the Admin Control Panel of the forums
+    7. Paste the Webhook URL into the "Incoming webhook url" field & Submit


### PR DESCRIPTION
Fixes https://github.com/srobo/tasks/issues/641

Deploy file backend for code submitter as implemented in https://github.com/PeterJCLaw/code-submitter/pull/15. This is for SR2021, where we're not using nemesis.

The mentioned `/srv/secrets/code-submitter-credentials.yaml` will need creating before deploying this, as noted in `new-machine.md`.